### PR TITLE
Readme, a few small method name changes, UIView @properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,33 +1,33 @@
 SimpleAL
 ========
 
-Simplifying AutoLayout
+Simple AutoLayout
 
-**Creating constraints and applying them directly to views**
+### How it works
 
-Left align a view that is 200px wide and as tall as its superview, all using AutoLayout:
+A UIView category creates al_* properties that return a SimpleALViewProperty object, which can be combined with other SimpleALViewProperty objects to generate NSLayoutConstraints, which can be used with standard Auto Layout code:
 
-    UIView *myView, superView;
+    NSLayoutConstraint *constraint = [myView.al_left equalToProperty:myOtherView.al_right];
+
+### SimpleAL vs Auto Layout
+
+##### Example 1
+
+Let's say we want to use Auto Layout to left align a view that is 200 points wide and is as tall as its superview. We'll assume that there's a view called myView and it's contained by superView. With SimpleAL, that looks like this:
 
     [superView addConstraint:[myView.al_left equalToViewProperty:superView.al_left]];
     [superView addConstraint:[myView.al_height lessThanOrEqualToViewProperty:superView.al_height]];
     [superView addConstraint:[myView.al_width lessThanOrEqualToValue:200]];
 
-The equivalent autolayout expressions for the the three respective expressions above are:
+In Auto Layout, that looks like this:
 
     [superView addConstraint:[NSLayoutConstraint constraintWithItem:subView attribute:NSLayoutAttributeLeft relatedBy:NSLayoutRelationGreaterThanOrEqualTo toItem:superView attribute:NSLayoutAttributeLeft multiplier:1.0 constant:0.0]];
     [superView addConstraint:[NSLayoutConstraint constraintWithItem:subView attribute:NSLayoutAttributeHeight relatedBy:NSLayoutRelationLessThanOrEqualTo toItem:superView attribute:NSLayoutAttributeHeight multiplier:1.0 constant:0.0]];
     [superView addConstraint:[NSLayoutConstraint constraintWithItem:subView attribute:NSLayoutAttributeWidth relatedBy:NSLayoutRelationEqualTo toItem:nil attribute:0 multiplier:1.0 constant:0.0]];
 
-All of the al_ methods return an NSLayoutConstraint.  So doing autolayout as it was designed is simple:
+##### Example 2
 
-    @property (nonatomic, retain) NSLayoutConstraint *constraintToRemoveLater;
-    self.constraintToRemoveLater = [myView.al_width greaterThanOrEqualToValue:200];
-
-    //later on
-    [myView removeConstraint:self.constraintToRemoveLater]; //!!
-
-Inequalities, offsets, and multipliers (an important part of AutoLayout) are all available:
+Inequalities, offsets, and multipliers are also important parts of Auto Layout and can be easily done with SimpleAL:
 
     // Make the left of myView greater than or equal to superView.left + 10.0
     [superView addConstraint:[myView.al_left greaterThanOrEqualToViewProperty:superView.al_left offset:10.0]];
@@ -35,45 +35,28 @@ Inequalities, offsets, and multipliers (an important part of AutoLayout) are all
     // myView's width >= (someView's width * 2.0) + 0.0
     [superView addConstraint:[myView.al_width greaterThanOrEqualToViewProperty:someView.al_width multipler:2.0 offset:0.0]];
 
-The equivalent autolayout expressions for the two inequality expressions above are:
+In Auto Layout, that looks like this:
 
     [superView addConstraint:[NSLayoutConstraint constraintWithItem:subView attribute:NSLayoutAttributeLeft relatedBy:NSLayoutRelationGreaterThanOrEqualTo toItem:superView attribute:NSLayoutAttributeLeft multiplier:1.0 constant:10.0]];
     [superView addConstraint:[NSLayoutConstraint constraintWithItem:subView attribute:NSLayoutAttributeWidth relatedBy:NSLayoutRelationGreaterThanOrEqualTo toItem:superView attribute:NSLayoutAttributeWidth multiplier:2.0 constant:0.0]];
 
-**Centering a view and top aligning it within its superview (10px offset on top).**
 
-Instead of:
+##### Example 3
+
+Let's say we want to center a view horizontally and align its top with its super view's top. In SimpleAL, that looks like this:
+
+    [myView.al_top equalToViewProperty:superView.al_top offset:10];
+    [myView.al_centerX equalToViewProperty:superView.al_centerX];
+
+In Auto Layout, that looks like this:
 
     [NSLayoutConstraint constraintWithItem:subView attribute:NSLayoutAttributeTop relatedBy:NSLayoutRelationEqual toItem:superView attribute:NSLayoutAttributeTop multiplier:1.0 constant:10.0];
     [NSLayoutConstraint constraintWithItem:subView attribute:NSLayoutAttributeCenterX relatedBy:NSLayoutRelationEqual toItem:superView attribute:NSLayoutAttributeCenterX multiplier:1.0 constant:0.0];
 
-We can do:
 
-    [subView.al_top equalToViewProperty:superView.al_top offset:10];
-    [subView.al_centerX equalToViewProperty:superView.al_centerX];
+### Generating more than one constraint at a time
 
-**Setting min widths (and other inequalities):**
-
-Instead of:
-
-    [NSLayoutConstraint constraintWithItem:subView attribute:NSLayoutAttributeWidth relatedBy:NSLayoutRelationLessThanOrEqualTo toItem:nil attribute:nil multiplier:1.0 constant:200.0];
-
-We can do:
-
-    [subView.al_width lessThanOrEqualToValue:200.0];
-
-Instead of:
-
-    [NSLayoutConstraint constraintWithItem:subView attribute:NSLayoutAttributeRight relatedBy:NSLayoutRelationLessThanOrEqualTo toItem:superView: attribute:NSLayoutAttributeRight multiplier:1.0 constant:10.0];
-
-We can do:
-
-    [subview.al_right lessThanOrEqualToViewProperty:parentView.al_right offset:10.0];
-
-
-**NSArray Utility Methods**
-
-Want to set some property on a large number of views at once?  You're in luck! SimpleAL extends NSArray to allow you to set a property on a large number of UIViews all at once.  If an object is not a UIView , then SimpleAL will assert.
+SimpleAL adds an NSArray category that allows you to use the al_* properties on arrays of views.
 
     [parentView addConstraints:[@[viewOne, viewTwo, viewThree].al_left greaterThanOrEqualToViewProperty:parentView.al_left]];
     [parentView addConstraints:[@[viewOne, viewTwo, viewThree].al_width equalToValue:200.0]];
@@ -84,16 +67,14 @@ An equivalent standard AutoLayout expression for just the bottom line is (somewh
         [NSLayoutConstraint constraintWithItem:viewTwo attribute:NSLayoutAttributeWidth relatedBy:NSLayoutRelationEqualTo toItem:nil attribute:0 multiplier:1.0 constant:200.0],
         [NSLayoutConstraint constraintWithItem:viewThree attribute:NSLayoutAttributeWidth relatedBy:NSLayoutRelationEqualTo toItem:nil attribute:0 multiplier:1.0 constant:200.0]]];
 
-**Enumeration over a list of views that hold a relation**
+Setting up constraints between sibling views is a common operation, and it's easy with SimpleAL. The following SimpleAL code generates constraints that express that each view in the array will be above the next consecutive view in the array:
 
-Setting a relationship between UIViews that are in a list (i.e. each view's bottom is related to the subsequent view's top) is very simple:
-
-    NSArray *constraints = [@[nameView, userProfileView, userLocationView, userHabitsView, userHobbiesView] al_enumerateViewPairsWithRelationshipBlock:(NSLayoutContraint *) ^(UIView *firstView, UIView *secondView) {
+    NSArray *constraints = [@[nameView, userProfileView, userLocationView, userHabitsView, userHobbiesView] al_constraintsByEnumeratingViewPairsWithRelationshipBlock:(NSLayoutContraint *) ^(UIView *firstView, UIView *secondView) {
         return [secondView.al_top equalToViewProperty:firstView.al_bottom offset:10.0];
         }];
     [superView addConstraints:constraints];
 
-The corresponding standard AutoLayout code for this is a mess, so the equivalent SimpleAL code is included below:
+The Auto Layout code to generate these constraints this is a mess, but the equivalent SimpleAL code without using the convenience method would be the following:
 
     [superView addConstraints:@[[userProfileView.al_top equalToViewProperty:nameView.al_bottom offset:10.0];
         [userLocationView.al_top equalToViewProperty:userProfileView.al_bottom offset:10.0];

--- a/SimpleAL/NSArray+SimpleAL.h
+++ b/SimpleAL/NSArray+SimpleAL.h
@@ -12,7 +12,7 @@ typedef NSLayoutConstraint *(^SimpleALViewEnumeratePairsBlock)(UIView *view1, UI
 
 @interface NSArray (SimpleAL)
 
-- (NSArray */*of NSLayoutConstraints */)al_enumerateViewPairsWithRelationshipBlock:(NSLayoutConstraint * (^)(UIView *viewOne, UIView *viewTwo))relationshipBlock;
+- (NSArray */*of NSLayoutConstraints */)al_constraintsByEnumeratingViewPairsWithRelationshipBlock:(NSLayoutConstraint * (^)(UIView *viewOne, UIView *viewTwo))relationshipBlock;
 - (SimpleALViewPropertyArray *)al_centerX;
 - (SimpleALViewPropertyArray *)al_centerY;
 - (SimpleALViewPropertyArray *)al_baseLine;

--- a/SimpleAL/NSArray+SimpleAL.m
+++ b/SimpleAL/NSArray+SimpleAL.m
@@ -97,7 +97,7 @@ static const NSUInteger kMinViewsForEnumeration = 3;
   }];
 }
 
-- (NSArray */*of NSLayoutConstraints */)al_enumerateViewPairsWithRelationshipBlock:(SimpleALViewEnumeratePairsBlock)enumeratePairsBlock {
+- (NSArray */*of NSLayoutConstraints */)al_constraintsByEnumeratingViewPairsWithRelationshipBlock:(SimpleALViewEnumeratePairsBlock)enumeratePairsBlock {
   NSAssert([self count] >= kMinViewsForEnumeration, @"Invalid number of views for %s. You must pass in at least %d views.", __func__, kMinViewsForEnumeration);
   UIView *firstView = nil, *secondView = nil;
   NSMutableArray *arrayOfConstraints = [NSMutableArray arrayWithCapacity:[self count] - 1];

--- a/SimpleAL/SimpleALViewProperty.h
+++ b/SimpleAL/SimpleALViewProperty.h
@@ -10,7 +10,7 @@
 @property (nonatomic, strong) UIView *view;
 @property (nonatomic, assign) NSLayoutAttribute attribute;
 
-+ (SimpleALViewProperty *)attributeWithView:(UIView *)view nsLayoutAttribute:(NSLayoutAttribute)attrib;
++ (SimpleALViewProperty *)attributeWithView:(UIView *)view layoutAttribute:(NSLayoutAttribute)attribute;
 
 - (NSLayoutConstraint *)equalToViewProperty:(SimpleALViewProperty *)viewProperty2;
 

--- a/SimpleAL/SimpleALViewProperty.m
+++ b/SimpleAL/SimpleALViewProperty.m
@@ -20,8 +20,8 @@
     return self;
 }
 
-+ (SimpleALViewProperty *)attributeWithView:(UIView *)view nsLayoutAttribute:(NSLayoutAttribute)attrib {
-    return [[SimpleALViewProperty alloc] initWithView:view layoutAttribute:attrib];
++ (SimpleALViewProperty *)attributeWithView:(UIView *)view layoutAttribute:(NSLayoutAttribute)attribute {
+    return [[SimpleALViewProperty alloc] initWithView:view layoutAttribute:attribute];
 }
 
 - (NSLayoutConstraint *)equalToViewProperty:(SimpleALViewProperty *)viewProperty2 {

--- a/SimpleAL/UIView+SimpleAL.h
+++ b/SimpleAL/UIView+SimpleAL.h
@@ -10,16 +10,16 @@
 
 @interface UIView (SimpleAL)
 
-- (SimpleALViewProperty *)al_centerX;
-- (SimpleALViewProperty *)al_centerY;
-- (SimpleALViewProperty *)al_baseLine;
-- (SimpleALViewProperty *)al_bottom;
-- (SimpleALViewProperty *)al_height;
-- (SimpleALViewProperty *)al_width;
-- (SimpleALViewProperty *)al_top;
-- (SimpleALViewProperty *)al_leading;
-- (SimpleALViewProperty *)al_left;
-- (SimpleALViewProperty *)al_right;
-- (SimpleALViewProperty *)al_trailing;
+@property (readonly) SimpleALViewProperty *al_baseLine;
+@property (readonly) SimpleALViewProperty *al_bottom;
+@property (readonly) SimpleALViewProperty *al_centerX;
+@property (readonly) SimpleALViewProperty *al_centerY;
+@property (readonly) SimpleALViewProperty *al_height;
+@property (readonly) SimpleALViewProperty *al_leading;
+@property (readonly) SimpleALViewProperty *al_left;
+@property (readonly) SimpleALViewProperty *al_right;
+@property (readonly) SimpleALViewProperty *al_top;
+@property (readonly) SimpleALViewProperty *al_trailing;
+@property (readonly) SimpleALViewProperty *al_width;
 
 @end

--- a/SimpleAL/UIView+SimpleAL.m
+++ b/SimpleAL/UIView+SimpleAL.m
@@ -12,47 +12,47 @@
 @implementation UIView (SimpleAL)
 
 - (SimpleALViewProperty *)al_centerX {
-    return [SimpleALViewProperty attributeWithView:self nsLayoutAttribute:NSLayoutAttributeCenterX];
+    return [SimpleALViewProperty attributeWithView:self layoutAttribute:NSLayoutAttributeCenterX];
 }
 
 - (SimpleALViewProperty *)al_centerY {
-    return [SimpleALViewProperty attributeWithView:self nsLayoutAttribute:NSLayoutAttributeCenterY];
+    return [SimpleALViewProperty attributeWithView:self layoutAttribute:NSLayoutAttributeCenterY];
 }
 
 - (SimpleALViewProperty *)al_baseLine {
-    return [SimpleALViewProperty attributeWithView:self nsLayoutAttribute:NSLayoutAttributeBaseline];
+    return [SimpleALViewProperty attributeWithView:self layoutAttribute:NSLayoutAttributeBaseline];
 }
 
 - (SimpleALViewProperty *)al_bottom {
-    return [SimpleALViewProperty attributeWithView:self nsLayoutAttribute:NSLayoutAttributeBottom];
+    return [SimpleALViewProperty attributeWithView:self layoutAttribute:NSLayoutAttributeBottom];
 }
 
 - (SimpleALViewProperty *)al_height {
-    return [SimpleALViewProperty attributeWithView:self nsLayoutAttribute:NSLayoutAttributeHeight];
+    return [SimpleALViewProperty attributeWithView:self layoutAttribute:NSLayoutAttributeHeight];
 }
 
 - (SimpleALViewProperty *)al_width {
-    return [SimpleALViewProperty attributeWithView:self nsLayoutAttribute:NSLayoutAttributeWidth];
+    return [SimpleALViewProperty attributeWithView:self layoutAttribute:NSLayoutAttributeWidth];
 }
 
 - (SimpleALViewProperty *)al_top {
-    return [SimpleALViewProperty attributeWithView:self nsLayoutAttribute:NSLayoutAttributeTop];
+    return [SimpleALViewProperty attributeWithView:self layoutAttribute:NSLayoutAttributeTop];
 }
 
 - (SimpleALViewProperty *)al_leading {
-    return [SimpleALViewProperty attributeWithView:self nsLayoutAttribute:NSLayoutAttributeLeading];
+    return [SimpleALViewProperty attributeWithView:self layoutAttribute:NSLayoutAttributeLeading];
 }
 
 - (SimpleALViewProperty *)al_left {
-    return [SimpleALViewProperty attributeWithView:self nsLayoutAttribute:NSLayoutAttributeLeft];
+    return [SimpleALViewProperty attributeWithView:self layoutAttribute:NSLayoutAttributeLeft];
 }
 
 - (SimpleALViewProperty *)al_trailing {
-    return [SimpleALViewProperty attributeWithView:self nsLayoutAttribute:NSLayoutAttributeTrailing];
+    return [SimpleALViewProperty attributeWithView:self layoutAttribute:NSLayoutAttributeTrailing];
 }
 
 - (SimpleALViewProperty *)al_right {
-    return [SimpleALViewProperty attributeWithView:self nsLayoutAttribute:NSLayoutAttributeRight];
+    return [SimpleALViewProperty attributeWithView:self layoutAttribute:NSLayoutAttributeRight];
 }
 
 @end


### PR DESCRIPTION
I used this to help me with preview markdown: http://tmpvar.com/markdown.html

I re-organized the readme a bunch. I also made a few method name changes that we had talked about. After going through the readme really thoroughly, I realized that we kept referring to this UIView al_\* methods as properties, so I went ahead and made them @property's.
